### PR TITLE
Batch transcryption based on EncryptedType enum

### DIFF
--- a/src/distributed.rs
+++ b/src/distributed.rs
@@ -203,12 +203,21 @@ impl PEPSystem {
         pseudonymize_batch(encrypted, pseudonymization_info, rng)
     }
 
-    pub fn transcrypt<E: Encrypted>(
+    pub fn transcrypt(
         &self,
-        encrypted: &E,
+        encrypted: &EncryptedType,
         transcryption_info: &PseudonymizationInfo,
-    ) -> E {
+    ) -> EncryptedType {
         transcrypt(encrypted, transcryption_info)
+    }
+
+    pub fn transcrypt_batch<R: RngCore + CryptoRng>(
+        &self,
+        encrypted: &mut [EncryptedType],
+        transcryption_info: &PseudonymizationInfo,
+        rng: &mut R,
+    ) -> Box<[EncryptedType]> {
+        transcrypt_batch(encrypted, transcryption_info, rng)
     }
 
 }

--- a/src/tests/distributed.rs
+++ b/src/tests/distributed.rs
@@ -63,7 +63,7 @@ fn n_pep() {
 
     let transcrypted_pseudo = systems.iter().fold(enc_pseudo.clone(), |acc, system| {
         let pseudo_info = system.pseudonymization_info(&pc_a, &pc_b, &ec_a1, &ec_b1);
-        system.transcrypt(&acc, &pseudo_info)
+        system.pseudonymize(&acc, &pseudo_info)
     });
 
     let transcrypted_data = systems.iter().fold(enc_data.clone(), |acc, system| {

--- a/src/tests/high_level.rs
+++ b/src/tests/high_level.rs
@@ -65,15 +65,31 @@ fn test_high_level_flow() {
 
     assert_eq!(data, rekeyed_dec);
 
-    let pseudonymized = transcrypt(&enc_pseudo, &pseudo_info);
+    let pseudonymized = pseudonymize(&enc_pseudo, &pseudo_info);
     let pseudonymized_dec = decrypt(&pseudonymized, &session2_secret);
 
     assert_ne!(pseudo, pseudonymized_dec);
 
-    let rev_pseudonymized = transcrypt(&pseudonymized, &pseudo_info.reverse());
+    let rev_pseudonymized = pseudonymize(&pseudonymized, &pseudo_info.reverse());
     let rev_pseudonymized_dec = decrypt(&rev_pseudonymized, &session1_secret);
 
     assert_eq!(pseudo, rev_pseudonymized_dec);
+
+    let rekeyed_transcrypt = transcrypt(&enc_data.into(), &pseudo_info);
+    let rekeyed_dec_transcrypt = decrypt(&EncryptedDataPoint::try_from(rekeyed_transcrypt).unwrap(), &session2_secret);
+
+    assert_eq!(data, rekeyed_dec_transcrypt);
+
+    let pseudonymized_transcrypt = transcrypt(&enc_pseudo.into(), &pseudo_info);
+    let pseudonymized_dec_transcrypt = decrypt(&EncryptedPseudonym::try_from(pseudonymized_transcrypt).unwrap(), &session2_secret);
+
+    assert_ne!(pseudo, pseudonymized_dec_transcrypt);
+    assert_eq!(pseudonymized_dec, pseudonymized_dec_transcrypt);
+
+    let rev_pseudonymized_transcrypt = transcrypt(&pseudonymized_transcrypt, &pseudo_info.reverse());
+    let rev_pseudonymized_dec_transcrypt = decrypt(&EncryptedPseudonym::try_from(rev_pseudonymized_transcrypt).unwrap(), &session1_secret);
+
+    assert_eq!(pseudo, rev_pseudonymized_dec_transcrypt);
 }
 #[test]
 fn test_batch() {


### PR DESCRIPTION
I figured it would be a nice feature to be able to call `batch transcrypt` on a mixed array of data and pseudonyms. 

To do this, however, we cannot use the `Encrypted` trait, since we cannot match that. For the existing `transcrypt` this is solved by introducing an `IS_PSEUDONYM` constant to each trait. But object safety prevents constructing a vector from mixed Encrypted structs. 

Therefore, I figured to use `enum`s instead, to distinguish between `EncryptedPseudonym`s and `EncryptedDataPoint`s. However, we still need to cast between `Encrypted` structs and `EncryptedType`s. 

Either we can implement this, or we can decide to not support mixed-type transcryption at all.